### PR TITLE
hide tooltip after clicking on line chart

### DIFF
--- a/src/barlinechart.ts
+++ b/src/barlinechart.ts
@@ -522,7 +522,10 @@ export class BarLineChart extends Chart {
                 )
                   vals.push(val);
             for (var line of this.lines)
-              if (line.onclick) line.onclick(vals[0]);
+              if (line.onclick) {
+                line.onclick(vals[0]);
+                this.linesTooltip.hide.call(this, vals[0]);
+              }
           }.bind(this)
         );
     }


### PR DESCRIPTION
When the line chart is clicked the popup stays there and it doesn’t disappear when the chart is unmounted. 
This happened because the `hide tooltip function` was not called after a click 